### PR TITLE
fix(JPAEntityProcessor): An empty collection does not return 204

### DIFF
--- a/jpa-examples/pom.xml
+++ b/jpa-examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.exxcellent.olingo-generic-processor</groupId>
 		<artifactId>olingo-generic-processor-root-pom</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.7.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/jpa-examples/tutorial-servlet-example/pom.xml
+++ b/jpa-examples/tutorial-servlet-example/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.apache.olingo.jpa.examples</groupId>
 		<artifactId>odata-jpa-examples</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.7.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/jpa/odata-jpa-metadata/pom.xml
+++ b/jpa/odata-jpa-metadata/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.apache.olingo.jpa</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.7.1-SNAPSHOT</version>
 	</parent>
 
 

--- a/jpa/odata-jpa-processor/pom.xml
+++ b/jpa/odata-jpa-processor/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.apache.olingo.jpa</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>odata-jpa-processor</artifactId>

--- a/jpa/odata-jpa-processor/src/main/java/org/apache/olingo/jpa/processor/core/processor/JPAEntityProcessor.java
+++ b/jpa/odata-jpa-processor/src/main/java/org/apache/olingo/jpa/processor/core/processor/JPAEntityProcessor.java
@@ -320,7 +320,7 @@ public class JPAEntityProcessor extends AbstractProcessor implements EntityProce
 	public void readEntityCollection(final ODataRequest request, final ODataResponse response, final UriInfo uriInfo,
 			final ContentType responseFormat) throws ODataApplicationException, ODataLibraryException {
 		final EntityCollection entityCollection = retrieveEntityData(request, uriInfo);
-		if (entityCollection.getEntities() == null || entityCollection.getEntities().isEmpty()) {
+		if (entityCollection.getEntities() == null) {
 			// 404 Not Found indicates that the resource specified by the request URL does
 			// not exist. The response body MAY
 			// provide additional information.

--- a/jpa/odata-jpa-processor/src/test/java/org/apache/olingo/jpa/processor/core/filter/TestJPACustomScalarFunctions.java
+++ b/jpa/odata-jpa-processor/src/test/java/org/apache/olingo/jpa/processor/core/filter/TestJPACustomScalarFunctions.java
@@ -57,7 +57,10 @@ public class TestJPACustomScalarFunctions {
 
 		final IntegrationTestHelper helper = new IntegrationTestHelper(emf,
 				"AdministrativeDivisions?$filter=org.apache.olingo.jpa.PopulationDensity(Area=$it/Area,Population=$it/Population) gt 1");
-		helper.assertStatus(204);
+		helper.assertStatus(200);
+		final ArrayNode values = helper.getValues();
+
+		assertEquals(0, values.size());
 	}
 
 	@Test

--- a/jpa/odata-jpa-processor/src/test/java/org/apache/olingo/jpa/processor/core/filter/TestJPAQueryWhereClause.java
+++ b/jpa/odata-jpa-processor/src/test/java/org/apache/olingo/jpa/processor/core/filter/TestJPAQueryWhereClause.java
@@ -568,7 +568,10 @@ public class TestJPAQueryWhereClause extends TestBase {
 
 		final IntegrationTestHelper helper = new IntegrationTestHelper(persistenceAdapter,
 				"Organizations?$filter=AdministrativeInformation/Created/By eq 'NonExistingUserId'");
-		helper.assertStatus(204);
+		helper.assertStatus(200);
+        final ArrayNode values = helper.getValues();
+
+        assertEquals(0, values.size());
 	};
 
 	@Ignore("RegionName currently not available in PostalAdress")

--- a/jpa/odata-jpa-test/pom.xml
+++ b/jpa/odata-jpa-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.apache.olingo.jpa</groupId>
 		<artifactId>odata-jpa</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>odata-jpa-test</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.exxcellent.olingo-generic-processor</groupId>
 		<artifactId>olingo-generic-processor-root-pom</artifactId>
-		<version>0.7.0-SNAPSHOT</version>
+		<version>0.7.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.exxcellent.olingo-generic-processor</groupId>
 	<artifactId>olingo-generic-processor-root-pom</artifactId>
-	<version>0.7.0-SNAPSHOT</version>
+	<version>0.7.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>olingo-generic-processor Root POM</name>


### PR DESCRIPTION
According to the OData protocol, `204` should only be returned if the resource is null. Currently we return null on an empty list result. 
cf: odata v4 errata:

> **9.1.4 Response Code 204 No Content**
> A request returns 204 No Content if the requested resource has the null value, or if the service
> applies a return=minimal preference. In this case, the response body MUST be empty.
