### PR TITLE
doc(*): add techdoc support for backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,9 +2,16 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: olingo-jpa-processor-v4
+  description: A library that automates the creation of a REST interface based on the odata protocol.
+  tags:
+    - "java"
+    - "odata"
+    - "jpa"
+    - "REST"
   annotations:
     github.com/project-slug: exxcellent/olingo-jpa-processor-v4
+    backstage.io/techdocs-ref: dir:.
 spec:
-  type: other
-  lifecycle: unknown
+  type: library
+  lifecycle: production
   owner: exxcellent

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: olingo-jpa-processor-docs
+docs_dir: 'doc'
+nav:
+  - Development: 
+    - "Table of content": development/TableOfContent.md
+    - "Project Structure": development/Project-Structure.md
+    - Build: development/Build.md
+    - Explanation: development/Explaining1.md
+    - Conversions: development/Conversions.md
+  - Integration:
+    - "Table of content": integrators/TableOfContent.md
+    - GetStarted: integrators/GetStarted.md
+    - AsWar: integrators/AsWar.md
+    - ServletSecurity: integrators/ServletSecurity.md
+    - DependencyInjection: integrators/DependencyInjection.md
+    - DTOConcept: integrators/DTOConcept.md
+    - Actions: integrators/Actions.md
+    - MoreHints: integrators/MoreHints.md
+    - MigrationGuide: integrators/MigrationGuide.md
+    - Annotations: integrators/Annotations.md
+plugins:
+  - techdocs-core


### PR DESCRIPTION
This adds a structure description for the documentation, so it can be displayed in backstage. Also adds an annotation in the catalog-info.yaml to reference this mkdocs.yml descriptor.