### PR TITLE
Fix $orderby over navigation properties

### DIFF
--- a/jpa/odata-jpa-processor/src/main/java/org/apache/olingo/jpa/processor/core/query/EntityQueryBuilder.java
+++ b/jpa/odata-jpa-processor/src/main/java/org/apache/olingo/jpa/processor/core/query/EntityQueryBuilder.java
@@ -34,6 +34,7 @@ import org.apache.olingo.server.api.serializer.SerializerException;
 import org.apache.olingo.server.api.uri.UriInfoResource;
 import org.apache.olingo.server.api.uri.UriResource;
 import org.apache.olingo.server.api.uri.UriResourceComplexProperty;
+import org.apache.olingo.server.api.uri.UriResourceCount;
 import org.apache.olingo.server.api.uri.UriResourceNavigation;
 import org.apache.olingo.server.api.uri.UriResourcePrimitiveProperty;
 import org.apache.olingo.server.api.uri.queryoption.CountOption;
@@ -186,7 +187,8 @@ public class EntityQueryBuilder extends AbstractCriteriaQueryBuilder<CriteriaQue
     }
 
     // TODO force orderBy if 'hasLimits'
-    cq.orderBy(createOrderByList(resultsetAffectingTables, uriResource.getOrderByOption()));
+    final List<Order> orderByList = createOrderByList(resultsetAffectingTables, uriResource.getOrderByOption());
+    cq.orderBy(orderByList);
 
     List<JPASelector> groupByAttributes = extractGroupByNaviAttributes();
     
@@ -212,8 +214,17 @@ public class EntityQueryBuilder extends AbstractCriteriaQueryBuilder<CriteriaQue
       }
       cq.groupBy(createGroupBy(groupByAttributes));
     }  else if (!orderByNaviAttributes.isEmpty()) {
-      //sorting requires also grouping?!
-      cq.groupBy(createGroupBy(usedPaths));
+      //sorting requires also grouping. Otherwise, strict SQL engines
+      // (e.g. SQL Server) reject the query with "not contained in GROUP BY clause".
+      // Skip aggregate expressions (e.g. COUNT) as they must not appear in GROUP BY.
+      final List<jakarta.persistence.criteria.Expression<?>> groupBy = createGroupBy(usedPaths);
+      for (final Order order : orderByList) {
+        final jakarta.persistence.criteria.Expression<?> orderExpr = order.getExpression();
+        if (orderExpr instanceof jakarta.persistence.criteria.Path && !groupBy.contains(orderExpr)) {
+          groupBy.add(orderExpr);
+        }
+      }
+      cq.groupBy(groupBy);
     }
 
     
@@ -536,18 +547,22 @@ public class EntityQueryBuilder extends AbstractCriteriaQueryBuilder<CriteriaQue
               final EdmNavigationProperty edmNaviProperty = ((UriResourceNavigation) uriResource).getProperty();
               From<?, ?> join;
               try {
-                join = joinTables
-                    .get(jpaEntityType.getAssociationPath(edmNaviProperty.getName()).getLeaf()
-                        .getInternalName());
+                final JPAAssociationPath associationPath = jpaEntityType
+                        .getAssociationPath(edmNaviProperty.getName());
+                join = joinTables.get(associationPath.getLeaf().getInternalName());
+                type = associationPath.getTargetType();
               } catch (final ODataJPAModelException e) {
                 throw new ODataJPAQueryException(e, HttpStatusCode.BAD_REQUEST);
               }
+              p = join;
+            } else if (uriResource instanceof UriResourceCount) {
+              // $orderby=NavigationProperty/$count - sort by count of related entities
               if (orderByItem.isDescending()) {
-                orders.add(cb.desc(cb.count(join)));
+                orders.add(cb.desc(cb.count(p)));
               } else {
-                orders.add(cb.asc(cb.count(join)));
+                orders.add(cb.asc(cb.count(p)));
               }
-            } // else if (uriResource instanceof UriResourceCount) {}
+            }
           }
         }
       }

--- a/jpa/odata-jpa-processor/src/main/java/org/apache/olingo/jpa/processor/core/query/EntityQueryBuilder.java
+++ b/jpa/odata-jpa-processor/src/main/java/org/apache/olingo/jpa/processor/core/query/EntityQueryBuilder.java
@@ -508,65 +508,68 @@ public class EntityQueryBuilder extends AbstractCriteriaQueryBuilder<CriteriaQue
 
     // TODO Functions and orderBy: Part 1 - 11.5.3.1 Invoking a Function
 
-    final List<Order> orders = new ArrayList<Order>();
-    if (orderByOption != null) {
-      final CriteriaBuilder cb = getCriteriaBuilder();
-      final JPAEntityType<?> jpaEntityType = getQueryEndType();
+    final List<Order> orders = new ArrayList<>();
+    if (orderByOption == null) {
+      return orders;
+    }
+    final CriteriaBuilder cb = getCriteriaBuilder();
+    final JPAEntityType<?> jpaEntityType = getQueryEndType();
 
-      for (final OrderByItem orderByItem : orderByOption.getOrders()) {
-        final Expression expression = orderByItem.getExpression();
-        if (expression instanceof Member) {
-          final UriInfoResource resourcePath = ((Member) expression).getResourcePath();
-          JPAStructuredType<?> type = jpaEntityType;
-          Path<?> p = joinTables.get(jpaEntityType.getInternalName());
-          assert p != null;
-          for (final UriResource uriResource : resourcePath.getUriResourceParts()) {
-            if (uriResource instanceof UriResourcePrimitiveProperty) {
-              final EdmProperty edmProperty = ((UriResourcePrimitiveProperty) uriResource).getProperty();
-              try {
-                final JPAAttribute<?> attribute = type.getPath(edmProperty.getName()).getLeaf();
-                p = p.get(attribute.getInternalName());
-              } catch (final ODataJPAModelException e) {
-                throw new ODataJPAQueryException(e, HttpStatusCode.BAD_REQUEST);
-              }
-              if (orderByItem.isDescending()) {
-                orders.add(cb.desc(p));
-              } else {
-                orders.add(cb.asc(p));
-              }
-            } else if (uriResource instanceof UriResourceComplexProperty) {
-              final EdmProperty edmProperty = ((UriResourceComplexProperty) uriResource).getProperty();
-              try {
-                final JPAAttribute<?> attribute = type.getPath(edmProperty.getName()).getLeaf();
-                p = p.get(attribute.getInternalName());
-                type = attribute.getStructuredType();
-              } catch (final ODataJPAModelException e) {
-                throw new ODataJPAQueryException(e, HttpStatusCode.BAD_REQUEST);
-              }
-            } else if (uriResource instanceof UriResourceNavigation) {
-              final EdmNavigationProperty edmNaviProperty = ((UriResourceNavigation) uriResource).getProperty();
-              From<?, ?> join;
-              try {
-                final JPAAssociationPath associationPath = jpaEntityType
-                        .getAssociationPath(edmNaviProperty.getName());
-                join = joinTables.get(associationPath.getLeaf().getInternalName());
-                type = associationPath.getTargetType();
-              } catch (final ODataJPAModelException e) {
-                throw new ODataJPAQueryException(e, HttpStatusCode.BAD_REQUEST);
-              }
-              p = join;
-            } else if (uriResource instanceof UriResourceCount) {
-              // $orderby=NavigationProperty/$count - sort by count of related entities
-              if (orderByItem.isDescending()) {
-                orders.add(cb.desc(cb.count(p)));
-              } else {
-                orders.add(cb.asc(cb.count(p)));
-              }
-            }
+    for (final OrderByItem orderByItem : orderByOption.getOrders()) {
+      final Expression expression = orderByItem.getExpression();
+      if (!(expression instanceof Member)) {
+        continue;
+      }
+      final UriInfoResource resourcePath = ((Member) expression).getResourcePath();
+      JPAStructuredType<?> type = jpaEntityType;
+      Path<?> currentPath = joinTables.get(jpaEntityType.getInternalName());
+      assert currentPath != null;
+      for (final UriResource uriResource : resourcePath.getUriResourceParts()) {
+        if (uriResource instanceof UriResourcePrimitiveProperty) {
+          final EdmProperty edmProperty = ((UriResourcePrimitiveProperty) uriResource).getProperty();
+          try {
+            final JPAAttribute<?> attribute = type.getPath(edmProperty.getName()).getLeaf();
+            currentPath = currentPath.get(attribute.getInternalName());
+          } catch (final ODataJPAModelException e) {
+            throw new ODataJPAQueryException(e, HttpStatusCode.BAD_REQUEST);
+          }
+          if (orderByItem.isDescending()) {
+            orders.add(cb.desc(currentPath));
+          } else {
+            orders.add(cb.asc(currentPath));
+          }
+        } else if (uriResource instanceof UriResourceComplexProperty) {
+          final EdmProperty edmProperty = ((UriResourceComplexProperty) uriResource).getProperty();
+          try {
+            final JPAAttribute<?> attribute = type.getPath(edmProperty.getName()).getLeaf();
+            currentPath = currentPath.get(attribute.getInternalName());
+            type = attribute.getStructuredType();
+          } catch (final ODataJPAModelException e) {
+            throw new ODataJPAQueryException(e, HttpStatusCode.BAD_REQUEST);
+          }
+        } else if (uriResource instanceof UriResourceNavigation) {
+          final EdmNavigationProperty edmNaviProperty = ((UriResourceNavigation) uriResource).getProperty();
+          From<?, ?> join;
+          try {
+            final JPAAssociationPath associationPath = jpaEntityType
+                    .getAssociationPath(edmNaviProperty.getName());
+            join = joinTables.get(associationPath.getLeaf().getInternalName());
+            type = associationPath.getTargetType();
+          } catch (final ODataJPAModelException e) {
+            throw new ODataJPAQueryException(e, HttpStatusCode.BAD_REQUEST);
+          }
+          currentPath = join;
+        } else if (uriResource instanceof UriResourceCount) {
+          // for $orderby=NavigationProperty/$count: sort by count of related entities
+          if (orderByItem.isDescending()) {
+            orders.add(cb.desc(cb.count(currentPath)));
+          } else {
+            orders.add(cb.asc(cb.count(currentPath)));
           }
         }
       }
     }
+
     return orders;
   }
 

--- a/jpa/odata-jpa-processor/src/test/java/org/apache/olingo/jpa/processor/core/query/TestJPAProcessorExpand.java
+++ b/jpa/odata-jpa-processor/src/test/java/org/apache/olingo/jpa/processor/core/query/TestJPAProcessorExpand.java
@@ -1,6 +1,8 @@
 package org.apache.olingo.jpa.processor.core.query;
 
+import static org.apache.http.HttpStatus.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -263,6 +265,23 @@ public class TestJPAProcessorExpand extends TestBase {
   }
 
   @Test
+  public void testExpandWithCountAndSecondOrderByCriteria() throws IOException, ODataException {
+    // Regression test for combined $orderby with $count and a second criteria:
+    // $orderby=Roles/$count desc,Address/Country asc
+    final URIBuilder uriBuilder = newUriBuilder().appendEntitySetSegment("Organizations")
+        .orderBy("Roles/$count desc,Address/Country asc")
+        .expandWithOptions("Roles", Map.of(QueryOption.COUNT, Boolean.TRUE));
+    final ServerCallSimulator helper = new ServerCallSimulator(persistenceAdapter, uriBuilder);
+    helper.execute(HttpStatusCode.OK.getStatusCode());
+
+    final ArrayNode orgs = helper.getJsonObjectValues();
+    assertFalse(orgs.isEmpty(), "Expected at least one result");
+    // Organization with most roles must still be first
+    final ObjectNode orgWithMostRoles = (ObjectNode) orgs.get(0);
+    assertEquals("3", orgWithMostRoles.get("ID").asText());
+  }
+
+  @Test
   public void testExpandWithInvalidNestedSkip() throws IOException, ODataException {
     final URIBuilder uriBuilder = newUriBuilder().appendEntitySetSegment("Organizations").orderBy("Roles/$count desc").expandWithOptions(
         "Roles", Map.of(QueryOption.SKIP, 1));
@@ -293,6 +312,48 @@ public class TestJPAProcessorExpand extends TestBase {
     assertEquals(3, roles.size());
     final ObjectNode firstRole = (ObjectNode) roles.get(0);
     assertEquals("C", firstRole.get("RoleCategory").asText());
+  }
+
+  @Test
+  public void testOrderByNavigationPropertyPrimitivePropertyDescending() throws IOException, ODataException {
+    // Regression test: $orderby=BusinessPartner/Country on BusinessPartnerRoles
+    final URIBuilder uriBuilder = newUriBuilder().appendEntitySetSegment("BusinessPartnerRoles")
+        .orderBy("BusinessPartner/Country desc")
+        .expand("BusinessPartner($select=Country)");
+    final ServerCallSimulator helper = new ServerCallSimulator(persistenceAdapter, uriBuilder);
+    helper.execute(SC_OK);
+
+    final ArrayNode roles = helper.getJsonObjectValues();
+    assertFalse(roles.isEmpty(), "Expected at least one result");
+    // Verify actual descending sort order by the navigation target's Country (alphabetically Z -> A)
+    for (int i = 0; i < roles.size() - 1; i++) {
+      final String countryCurrent = roles.get(i).get("BusinessPartner").get("Country").asText();
+      final String countryNext = roles.get(i + 1).get("BusinessPartner").get("Country").asText();
+      assertTrue(countryCurrent.compareTo(countryNext) >= 0,
+          "Expected descending alphabetical order by BusinessPartner/Country but got '"
+              + countryCurrent + "' before '" + countryNext + "' at index " + i);
+    }
+  }
+
+  @Test
+  public void testOrderByNavigationPropertyPrimitivePropertyAscending() throws IOException, ODataException {
+    // Regression test: $orderby=BusinessPartner/Country on BusinessPartnerRoles (ascending, default direction)
+    final URIBuilder uriBuilder = newUriBuilder().appendEntitySetSegment("BusinessPartnerRoles")
+        .orderBy("BusinessPartner/Country")
+        .expand("BusinessPartner($select=Country)");
+    final ServerCallSimulator helper = new ServerCallSimulator(persistenceAdapter, uriBuilder);
+    helper.execute(SC_OK);
+
+    final ArrayNode roles = helper.getJsonObjectValues();
+    assertFalse(roles.isEmpty(), "Expected at least one result");
+    // Verify actual ascending sort order by the navigation target's Country (alphabetically A -> Z)
+    for (int i = 0; i < roles.size() - 1; i++) {
+      final String countryCurrent = roles.get(i).get("BusinessPartner").get("Country").asText();
+      final String countryNext = roles.get(i + 1).get("BusinessPartner").get("Country").asText();
+      assertTrue(countryCurrent.compareTo(countryNext) <= 0,
+          "Expected ascending alphabetical order by BusinessPartner/Country but got '"
+              + countryCurrent + "' before '" + countryNext + "' at index " + i);
+    }
   }
 
   @Test


### PR DESCRIPTION
With the current version, when using $orderby on a navigation property, an error occurs.

**Example Query:** /EntityA?orderby=EntityB/FieldA

This throws a NPE:

```
	Suppressed: java.lang.NullPointerException: Cannot invoke "org.apache.olingo.jpa.metadata.core.edm.mapper.api.JPASelector.getLeaf()" because the return value of 
	"org.apache.olingo.jpa.metadata.core.edm.mapper.api.JPAStructuredType.getPath(String)" is null
		at org.apache.olingo.jpa.processor.core.query.EntityQueryBuilder.createOrderByList(EntityQueryBuilder.java:464)
		at org.apache.olingo.jpa.processor.core.query.EntityQueryBuilder.executeInternal(EntityQueryBuilder.java:181)
		at org.apache.olingo.jpa.processor.core.query.EntityQueryBuilder.execute(EntityQueryBuilder.java:152)
		at org.apache.olingo.jpa.processor.impl.JPAStructureProcessor.loadDataBaseData(JPAStructureProcessor.java:420)
		at org.apache.olingo.jpa.processor.impl.JPAStructureProcessor.retrieveEntityResult(JPAStructureProcessor.java:405)
		at org.apache.olingo.jpa.processor.impl.JPAStructureProcessor.readEntityCollection(JPAStructureProcessor.java:439)
		at org.apache.olingo.server.core.ODataDispatcher.handleEntityCollectionDispatching(ODataDispatcher.java:541)
		at org.apache.olingo.server.core.ODataDispatcher.handleEntityDispatching(ODataDispatcher.java:523)
		at org.apache.olingo.server.core.ODataDispatcher.handleResourceDispatching(ODataDispatcher.java:153)
		at org.apache.olingo.server.core.ODataDispatcher.dispatch(ODataDispatcher.java:119)
		at org.apache.olingo.server.core.ODataHandlerImpl.processInternal(ODataHandlerImpl.java:168)
		at org.apache.olingo.server.core.ODataHandlerImpl.process(ODataHandlerImpl.java:89)
		at org.apache.olingo.jpa.processor.core.api.JPAODataHttpHandlerImpl.processTransactional(JPAODataHttpHandlerImpl.java:103)
		at org.apache.olingo.jpa.processor.core.api.JPAODataHttpHandlerImpl.process(JPAODataHttpHandlerImpl.java:151)
		at org.apache.olingo.jpa.processor.core.api.JPAODataServletHandler.process(JPAODataServletHandler.java:94)
```

The issue: The navigation branch in EntityQueryBuilder.createOrderByList() incorrectly assumes that a navigation segment is always followed by $count, and immediately produced ORDER BY COUNT(join). This causes two problems:
1. For $orderby=NavProperty/Field, the type cursor was never updated to the navigation target, so the next segment tried to resolve the field on the wrong entity type, resulting in the NPE.
2. The generated SQL always used COUNT() even when the intent was to sort by a primitive property of the related entity.

Changes in createOrderByList():
- Navigation branch now only advances the path cursor (currentPath "p") and type cursor ("type") to the join target, letting the loop continue to resolve the next segment (for example, a primitive property).
- New separate UriResourceCount section handles the $count case explicitly
- Optionally, a minor refactoring to reduce nesting and improve variable naming, for better readability (at least in my opinion). It's a separate commit so it can be easily reverted if you don't want it.

Changes in executeInternal():
- ORDER BY expressions that reference joined tables are added to the GROUP BY clause, so strict SQL engines don't reject the query with "not contained in GROUP BY clause". Note that the H2 tests run perfectly fine without the GROUP BY. In my own project (using SQL Server), there's errors if GROUP BY isn't added here. COUNT is filtered out because otherwise it also gets added to the GROUP BY, which will throw.


---

**For testing:**
- I added test cases for ordering by a navigation property in ascending and descending order
- The comment in createOrderByList() mentioned combining two orderbys (one for count, one for a navigation property). I added a test case to confirm that this works now

We currently have a workaround in our project, so we don't have time pressure.
It works by removing the problematic $orderby from the client query and manually adding a hardcoded ORDER BY / GROUP BY via the query customizer. Since we control the client and there's only a single case where this bug is relevant, this is fine for now. However, this doesn't scale well for the future, of course.



I adapted the same changes for the JavaX branch as well and have pushed it. Let me know what you want me to do with it.
/fix/javax-fix-orderby-for-navigation-properties